### PR TITLE
Ensure $atts is an array

### DIFF
--- a/shortcodes/class.map-shortcode.php
+++ b/shortcodes/class.map-shortcode.php
@@ -32,6 +32,8 @@ class Leaflet_Map_Shortcode extends Leaflet_Shortcode {
 	protected function getAtts ($atts, $content = null) {
 		if ($atts) extract($atts);
 
+		settype( $atts, 'array' );
+		
 		$settings = Leaflet_Map_Plugin_Settings::init();
 
 		$atts['zoom'] = empty($zoom) ? $settings->get('default_zoom') : $zoom;


### PR DESCRIPTION
I encountered a situation where $atts was typed as a string. This PR ensures that the variable is always an array