### PR TITLE
Fixed error in php7

### DIFF
--- a/shortcodes/class.image-shortcode.php
+++ b/shortcodes/class.image-shortcode.php
@@ -19,7 +19,7 @@ class Leaflet_Image_Shortcode extends Leaflet_Map_Shortcode {
     * @param array $atts
     * @return string $content produced by adding atts to JavaScript
     */
-	protected function getHTML ($atts, $content) {
+	protected function getHTML ($atts, $content = null) {
 		extract($this->getAtts($atts));
 
 		/* only required field for image map (src/source) */


### PR DESCRIPTION
Hi i did a server update, and it took my whole website offline. It was because suddenly this error was considered a fatal error. (not sure what it was before). 

error:
PHP Fatal error:  Declaration of Leaflet_Image_Shortcode::getHTML($atts, $content) must be compatible with Leaflet_Map_Shortcode::getHTML($atts, $content = NULL) in /usr/share/webapps/wordpress/wp-content/plugins/leaflet-map/shortcodes/class.image-shortcode.php on line 16