### PR TITLE
leaflet-circle shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Add a marker to any map by adding `[leaflet-marker]` after any `[leaflet-map]` s
 
 Add a line to the map by adding `[leaflet-line]`. You can specify the postions with a list separated by semi-colon `;` or bar `|` using lat/lng: `[leaflet-line latlngs="41, 29; 44, 18"]` or addresses: `[leaflet-line addresses="Istanbul; Sarajevo"]`, or x/y coordinates for image maps.
 
+### [leaflet-circle]
+
+Add a circle to the map by adding `[leaflet-circle]`. You can specify the position using `lat` and `lng` and the radius in meters using `radius`. You can also customize the style using [Leaflet's Path options](https://leafletjs.com/reference-1.3.4.html#path-option). Example: `[leaflet-circle message="max distance" lng=5.117909610271454 lat=52.097914814706094 radius=17500 color="#0DC143" fillOpacity=0.1]`.
+
 ### [leaflet-geojson]
 
 [![Random GeoJSON created by me](https://imgur.com/fJktgtI.jpg)](https://gist.github.com/bozdoz/064a7101b95a324e8852fe9381ab9a18)

--- a/class.leaflet-map.php
+++ b/class.leaflet-map.php
@@ -59,6 +59,10 @@ class Leaflet_Map
             'file' => 'class.line-shortcode.php',
             'class' => 'Leaflet_Line_Shortcode'
         ),
+        'leaflet-circle' => array(
+            'file' => 'class.circle-shortcode.php',
+            'class' => 'Leaflet_Circle_Shortcode'
+        ),
         'leaflet-map' => array(
             'file' => 'class.map-shortcode.php',
             'class' => 'Leaflet_Map_Shortcode'
@@ -296,7 +300,7 @@ class Leaflet_Map
     /**
      * Add Popups to Shapes
      *
-     * used by leaflet-marker and leaflet-line
+     * used by leaflet-marker, leaflet-line and leaflet-circle
      *
      * @param array  $atts    user-input array
      * @param string $content text to display

--- a/readme.txt
+++ b/readme.txt
@@ -46,6 +46,8 @@ Add a marker to any map by adding `[leaflet-marker]` after any `[leaflet-map]` s
 
 Add a line to the map by adding `[leaflet-line]`. You can specify the postions with a list separated by semi-colon `;` or bar `|` using lat/lng: `[leaflet-line latlngs="41, 29; 44, 18"]` or addresses: `[leaflet-line addresses="Istanbul; Sarajevo"]`, or x/y coordinates for image maps.
 
+Add a circle to the map by adding `[leaflet-circle]`. You can specify the position using `lat` and `lng` and the radius in meters using `radius`. You can also customize the style using [Leaflet's Path options](https://leafletjs.com/reference-1.3.4.html#path-option). Example: `[leaflet-circle message="max distance" lng=5.117909610271454 lat=52.097914814706094 radius=17500 color="#0DC143" fillOpacity=0.1]`.
+
 Or you can add a geojson shape via a url (work in progress): `[leaflet-geojson src="https://example.com/path/to.geojson"]`
 
 = Image Maps =

--- a/shortcodes/class.circle-shortcode.php
+++ b/shortcodes/class.circle-shortcode.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Circle Shortcode
+ *
+ * Use with [leaflet-circle ...]
+ *
+ * PHP Version 5.5
+ *
+ * @category Shortcode
+ * @author   Peter Uithoven <peter@peteruithoven.nl>
+ */
+
+// Exit if accessed directly
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+require_once LEAFLET_MAP__PLUGIN_DIR . 'shortcodes/class.shortcode.php';
+
+/**
+ * Leaflet Line Shortcode Class
+ */
+class Leaflet_Circle_Shortcode extends Leaflet_Shortcode
+{
+    /**
+     * Get Script for Shortcode
+     *
+     * @param string $atts    shortcode attributes
+     * @param string $content optional
+     *
+     * @return string HTML
+     */
+    protected function getHTML($atts='', $content=null)
+    {
+        if (!empty($atts)) {
+            extract($atts);
+        }
+
+        $style_json = $this->LM->get_style_json($atts);
+
+        $fitbounds = empty($fitbounds) ? 0 : $fitbounds;
+
+        /* add to user contributed lat lng */
+        $lat = empty($lat) ? ( empty($y) ? '0' : $y ) : $lat;
+        $lng = empty($lng) ? ( empty($x) ? '0' : $x ) : $lng;
+        $radius = empty($radius) ? '0' : $radius;
+
+        ob_start();
+        ?>
+        <script>
+        WPLeafletMapPlugin.add(function () {
+            var previous_map = WPLeafletMapPlugin.getCurrentMap(),
+                circle = L.circle([<?php echo $lat . ', ' . $lng . '], {radius: ' . $radius . '}'; ?>),
+                fitbounds = <?php echo $fitbounds; ?>;
+            circle.setStyle(<?php echo $style_json; ?>);
+            circle.addTo( previous_map );
+            if (fitbounds) {
+                // zoom the map to the polyline
+                previous_map.fitBounds( circle.getBounds() );
+            }
+        <?php
+            $this->LM->add_popup_to_shape($atts, $content, 'circle');
+        ?>
+        });
+        </script>
+        <?php
+        return ob_get_clean();
+    }
+}

--- a/shortcodes/class.circle-shortcode.php
+++ b/shortcodes/class.circle-shortcode.php
@@ -40,18 +40,35 @@ class Leaflet_Circle_Shortcode extends Leaflet_Shortcode
 
         $fitbounds = empty($fitbounds) ? 0 : $fitbounds;
 
-        /* add to user contributed lat lng */
+        if (!empty($address)) {
+            include_once LEAFLET_MAP__PLUGIN_DIR . 'class.geocoder.php';
+            $location = new Leaflet_Geocoder( $address );
+            $lat = $location->lat;
+            $lng = $location->lng;
+        }
+
         $lat = empty($lat) ? ( empty($y) ? '0' : $y ) : $lat;
         $lng = empty($lng) ? ( empty($x) ? '0' : $x ) : $lng;
-        $radius = empty($radius) ? '0' : $radius;
+        $radius = empty($radius) ? '1000' : $radius;
 
         ob_start();
         ?>
         <script>
         WPLeafletMapPlugin.add(function () {
             var previous_map = WPLeafletMapPlugin.getCurrentMap(),
-                circle = L.circle([<?php echo $lat . ', ' . $lng . '], {radius: ' . $radius . '}'; ?>),
-                fitbounds = <?php echo $fitbounds; ?>;
+                fitbounds = <?php echo $fitbounds; ?>,
+                is_image = previous_map.is_image_map,
+                lat = <?php echo $lat; ?>,
+                lng = <?php echo $lng; ?>,
+                radius = <?php echo $radius; ?>;
+
+            // update lat lng to previous map's center
+            if (!lat && !lng && !is_image) {
+                var map_center = previous_map.getCenter();
+                lat = map_center.lat;
+                lng = map_center.lng;
+            }
+            var circle = L.circle([lat, lng], {radius: radius});
             circle.setStyle(<?php echo $style_json; ?>);
             circle.addTo( previous_map );
             if (fitbounds) {

--- a/templates/shortcode-helper.php
+++ b/templates/shortcode-helper.php
@@ -77,7 +77,7 @@
                     '[leaflet-map lat=41 lng=29 scrollwheel=1 zoom=6]',
                     '[leaflet-line latlngs="41, 29; 44, 18;"]'
                     ),
-                __("Basic Circle w/Scrollwheel", 'leaflet-map') => array(
+                __("Basic Circle", 'leaflet-map') => array(
                     '[leaflet-map lat=52 lng=5 zoom=9]',
                     '[leaflet-circle lat=52 lng=5 radius=17500]'
                     ),

--- a/templates/shortcode-helper.php
+++ b/templates/shortcode-helper.php
@@ -77,6 +77,10 @@
                     '[leaflet-map lat=41 lng=29 scrollwheel=1 zoom=6]',
                     '[leaflet-line latlngs="41, 29; 44, 18;"]'
                     ),
+                __("Basic Circle w/Scrollwheel", 'leaflet-map') => array(
+                    '[leaflet-map lat=52 lng=5 zoom=9]',
+                    '[leaflet-circle lat=52 lng=5 radius=17500]'
+                    ),
                 __("Fitted Colored Line on Addresses", 'leaflet-map') => array(
                     '[leaflet-map]',
                     '[leaflet-line color="purple" addresses="Sayulita; Puerto Vallarta;" fitline=1]'


### PR DESCRIPTION
Adds support for a leaflet-circle shortcode. 
Example:
```
[leaflet-circle message="max distance" lng=5 lat=52 radius=17500 color="#0DC143" fillOpacity=0.1]
```

I've tried to also add some documentation and examples. 

Please let me know if there is something that I can improve. 