### PR TITLE
Add option to use CircleMarkers with GeoJSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,8 @@ Or you can add a geojson shape via a url:
 | `popup_text`     | Text for any popups when shapes are clicked |
 | `popup_property` | Name of the geojson property that contains popup content |
 | `fitbounds`      | Fit the map to the bounds of all shapes (instead of whatever center you gave the map originally) |
+| `circleMarker`   | Display circles instead of markers. Vastly improves performance on maps with a lot of points. |
+| `radius`         | Radius of the circles, when `circleMarkers` is set |
 
 Includes all style options: See https://leafletjs.com/reference-1.3.4.html#path.  Also, if you want to add feature
 properties to the popups, use the inner content and curly brackets to substitute the values:

--- a/class.leaflet-map.php
+++ b/class.leaflet-map.php
@@ -279,6 +279,7 @@ class Leaflet_Map
             'fillOpacity' => isset($fillopacity) ? $fillopacity : null,
             'fillRule' => isset($fillrule) ? $fillrule : null,
             'className' => isset($classname) ? $classname : null,
+            'radius' => isset($radius) ? $radius : null
             );
 
         $args = array(
@@ -294,7 +295,8 @@ class Leaflet_Map
             'fillColor' => FILTER_SANITIZE_STRING,
             'fillOpacity' => FILTER_VALIDATE_FLOAT,
             'fillRule' => FILTER_SANITIZE_STRING,
-            'className' => FILTER_SANITIZE_STRING
+            'className' => FILTER_SANITIZE_STRING,
+            'radius' => FILTER_VALIDATE_FLOAT
             );
 
         return $this->json_sanitize($style, $args);

--- a/shortcodes/class.geojson-shortcode.php
+++ b/shortcodes/class.geojson-shortcode.php
@@ -69,6 +69,7 @@ class Leaflet_Geojson_Shortcode extends Leaflet_Shortcode
         $style_json = $this->LM->get_style_json($atts);
 
         $fitbounds = empty($fitbounds) ? 0 : $fitbounds;
+        $circleMarker = empty($circleMarker) ? 0 : $circleMarker;
 
         // shortcode content becomes popup text
         $content_text = empty($content) ? '' : $content;
@@ -99,8 +100,10 @@ class Leaflet_Geojson_Shortcode extends Leaflet_Shortcode
                         type: '<?php echo $class::$type; ?>',
                         style : layerStyle,
                         onEachFeature : onEachFeature,
+                        pointToLayer: pointToLayer
                     }),
                     fitbounds = <?php echo $fitbounds; ?>,
+                    circleMarker = <?php echo $circleMarker; ?>,
                     popup_text = window.WPLeafletMapPlugin.unescape('<?php echo $popup_text; ?>'),
                     popup_property = '<?php echo $popup_property; ?>',
                     group = window.WPLeafletMapPlugin.getCurrentGroup();   
@@ -129,7 +132,7 @@ class Leaflet_Geojson_Shortcode extends Leaflet_Shortcode
                     }
                     style = L.Util.extend(style, default_style);
                     return style;
-                }      
+                }
                 function onEachFeature (feature, layer) {
                     var props = feature.properties || {};
                     var text = popup_property
@@ -141,7 +144,14 @@ class Leaflet_Geojson_Shortcode extends Leaflet_Shortcode
                     if (text) {
                         layer.bindPopup( text );
                     }
-                }  
+                }
+                function pointToLayer (feature, latlng) {
+                    if (circleMarker) {
+                        return L.circleMarker(latlng);
+                    } else {
+                        return L.marker(latlng);
+                    }
+                }
             });
         </script>
         <?php

--- a/templates/shortcode-helper.php
+++ b/templates/shortcode-helper.php
@@ -100,9 +100,9 @@
                 __("Disable all Interaction", 'leaflet-map') => array(
                     '[leaflet-map address="las vegas" !boxZoom !doubleClickZoom !dragging !keyboard !scrollwheel !attribution !touchZoom]',
                     ),
-                __("Add GeoJSON by URL (with popups)", 'leaflet-map') => array(
+                __("Add GeoJSON by URL (with circle markers and popups)", 'leaflet-map') => array(
                     '[leaflet-map fitbounds doubleClickZoom scrollwheel]',
-                    '[leaflet-geojson src=https://gist.githubusercontent.com/bozdoz/064a7101b95a324e8852fe9381ab9a18/raw/03f4f54b13a3a7e256732760a8b679818d9d36fc/map.geojson]{popup-text}[/leaflet-geojson]'
+                    '[leaflet-geojson circleMarker src=https://gist.githubusercontent.com/bozdoz/064a7101b95a324e8852fe9381ab9a18/raw/03f4f54b13a3a7e256732760a8b679818d9d36fc/map.geojson]{popup-text}[/leaflet-geojson]'
                     ),
                 __("Add KML by URL", 'leaflet-map') => array(
                     '[leaflet-map fitbounds]',


### PR DESCRIPTION
This could be a solution for issue #79.

Basically, it adds a new option `circleMarker` to `[leaflet-geojson]`. If set, the `pointToLayer`-function is called, which vastly increases the performance with a lot of points as all those points get rendered on a single canvas.  In the prior way, each regular marker represents a single DOM element.

Adding this function doesn't affect any old maps at all.
Readme and examples page were extended to inform about this option.