### PR TITLE
Raw map options for tap and raw JavaScript

### DIFF
--- a/class.admin.php
+++ b/class.admin.php
@@ -103,7 +103,14 @@ class Leaflet_Map_Admin
     public function shortcode_page()
     {
         wp_enqueue_style('leaflet_admin_stylesheet');
-        wp_enqueue_script('custom_plugin_js', plugins_url('scripts/shortcode-helper.min.js', LEAFLET_MAP__PLUGIN_FILE), Array('leaflet_js'), false);
+        
+        if (defined('WP_DEBUG') && WP_DEBUG) {
+            $minified = '';
+        } else {
+            $minified = '.min';
+        }
+
+        wp_enqueue_script('custom_plugin_js', plugins_url(sprintf('scripts/shortcode-helper%s.js', $minified), LEAFLET_MAP__PLUGIN_FILE), Array('leaflet_js'), false);
 
         include 'templates/shortcode-helper.php';
     }

--- a/class.leaflet-map.php
+++ b/class.leaflet-map.php
@@ -347,4 +347,67 @@ class Leaflet_Map
         include_once LEAFLET_MAP__PLUGIN_DIR . 'class.plugin-settings.php';
         return Leaflet_Map_Plugin_Settings::init();
     }
+
+    /**
+     * Parses liquid tags from a string
+     * 
+     * @param string $str
+     * 
+     * @return array|null
+     */
+    public function liquid ($str) {
+        if (!is_string($str)) {
+            return null;
+        }
+        $templateRegex = "/\{ *(.*?) *\}/";
+        preg_match_all($templateRegex, $str, $matches);
+               
+        if (!$matches[1]) {
+            return null;
+        }
+        
+        $str = $matches[1][0];
+
+        $tags = explode(' | ', $str);
+
+        $original = array_shift($tags);
+
+        if (!$tags) {
+            return null;
+        }
+
+        $output = array();
+
+        foreach ($tags as $tag) {
+            $tagParts = explode(': ', $tag);
+            $tagName = array_shift($tagParts);
+            $tagValue = implode(': ', $tagParts) || true;
+
+            $output[$tagName] = $tagValue;
+        }
+
+        // preserve the original
+        $output['original'] = $original;
+
+        return $output;
+    }
+
+    /**
+     * Renders a json-like string, removing quotes for values
+     * 
+     * allows JavaScript variables to be added directly 
+     * 
+     * @return string
+     */
+    public function rawDict ($arr) {
+        $obj = '{';
+        
+        foreach ($arr as $key=>$val) {
+            $obj .= "\"$key\": $val,";
+        }
+
+        $obj .= '}';
+
+        return $obj;
+    }
 }

--- a/shortcodes/class.image-shortcode.php
+++ b/shortcodes/class.image-shortcode.php
@@ -59,7 +59,7 @@ class Leaflet_Image_Shortcode extends Leaflet_Map_Shortcode
                     scrollWheelZoom: <?php echo $scrollwheel; ?>,
                     doubleClickZoom: <?php echo $doubleclickzoom; ?>,
                     attributionControl: false
-                }, <?php echo $more_options; ?>, {
+                }, <?php echo $map_options; ?>, {
                     crs: L.CRS.Simple
                 });
             var image_src = '<?php echo $source; ?>';

--- a/shortcodes/class.map-shortcode.php
+++ b/shortcodes/class.map-shortcode.php
@@ -71,15 +71,20 @@ class Leaflet_Map_Shortcode extends Leaflet_Shortcode
         $atts['height'] = empty($height) ? 
             $settings->get('default_height') : $height;
         $atts['width'] = empty($width) ? $settings->get('default_width') : $width;
-        $atts['zoomcontrol'] = array_key_exists('zoomcontrol', $atts) ?
-            $zoomcontrol : $settings->get('show_zoom_controls');
+        $atts['zoomcontrol'] = isset($zoomControl) 
+            ? $zoomControl
+            : (array_key_exists('zoomcontrol', $atts) 
+                ? $zoomcontrol 
+                : $settings->get('show_zoom_controls'));
         $atts['min_zoom'] = array_key_exists('min_zoom', $atts) ? 
             $min_zoom : $settings->get('default_min_zoom');
         $atts['max_zoom'] = empty($max_zoom) ? 
             $settings->get('default_max_zoom') : $max_zoom;
-        $atts['scrollwheel'] = array_key_exists('scrollwheel', $atts) 
-            ? $scrollwheel 
-            : $settings->get('scroll_wheel_zoom');
+        $atts['scrollwheel'] = isset($scrollWheelZoom)
+            ? $scrollWheelZoom
+            : (array_key_exists('scrollwheel', $atts) 
+                ? $scrollwheel 
+                : $settings->get('scroll_wheel_zoom'));
         $atts['doubleclickzoom'] = array_key_exists('doubleclickzoom', $atts) ? 
             $doubleclickzoom : $settings->get('double_click_zoom');
         
@@ -143,6 +148,13 @@ class Leaflet_Map_Shortcode extends Leaflet_Shortcode
             'touchZoom' => isset($touchZoom) ? $touchZoom : null,
             'dragging' => isset($dragging) ? $dragging : null,
             'keyboard' => isset($keyboard) ? $keyboard : null,
+            'zoomAnimation' => isset($zoomAnimation) ?  $zoomAnimation : null,
+            'fadeAnimation' => isset($fadeAnimation) ?  $fadeAnimation : null,
+            'markerZoomAnimation' => isset($markerZoomAnimation) ?  $markerZoomAnimation : null,
+            'inertia' => isset($inertia) ?  $inertia : null,
+            'worldCopyJump' => isset($worldCopyJump) ?  $worldCopyJump : null,
+            'tap' => isset($tap) ? $tap : null,
+            'bounceAtZoomLimits' => isset($bounceAtZoomLimits) ? $bounceAtZoomLimits : null,
         );
 
         // filter out nulls

--- a/shortcodes/class.shortcode.php
+++ b/shortcodes/class.shortcode.php
@@ -16,6 +16,9 @@
  */
 abstract class Leaflet_Shortcode
 {
+    /**
+     * @var Leaflet_Map
+     */
     protected $LM;
 
     /**
@@ -31,23 +34,26 @@ abstract class Leaflet_Shortcode
      */
     abstract protected function getHTML($atts='', $content=null);
 
-    public static function getClass()
+    /**
+     * @return $this
+     */
+    public static function getInstance()
     {
-        return function_exists('get_called_class') ? get_called_class() : __CLASS__;
+        $class = function_exists('get_called_class') ? get_called_class() : __CLASS__;
+        return new $class();
     }
 
     /**
      * Instantiate class and get HTML for shortcode
      *
-     * @param array  $atts    string|array
-     * @param string $content Optional
+     * @param array|string|null $atts    string|array
+     * @param string|null       $content Optional
      * 
-     * @return string (see above)
+     * @return string HTML
      */
     public static function shortcode($atts = '', $content = null)
     {
-        $class = self::getClass();
-        $instance = new $class();
+        $instance = self::getInstance();
 
         // swap sequential array with associative array
         // this enables assumed-boolean attributes,

--- a/shortcodes/class.shortcode.php
+++ b/shortcodes/class.shortcode.php
@@ -34,13 +34,9 @@ abstract class Leaflet_Shortcode
      */
     abstract protected function getHTML($atts='', $content=null);
 
-    /**
-     * @return $this
-     */
-    public static function getInstance()
+    public static function getClass()
     {
-        $class = function_exists('get_called_class') ? get_called_class() : __CLASS__;
-        return new $class();
+        return function_exists('get_called_class') ? get_called_class() : __CLASS__;
     }
 
     /**
@@ -53,7 +49,8 @@ abstract class Leaflet_Shortcode
      */
     public static function shortcode($atts = '', $content = null)
     {
-        $instance = self::getInstance();
+        $class = self::getClass();
+        $instance = new $class();
 
         // swap sequential array with associative array
         // this enables assumed-boolean attributes,


### PR DESCRIPTION
adds option for disabling tap: `[leaflet-map !tap]`

adds (advanced) ability to add raw JavaScript in a attribute value:

`[leaflet-map dragging="{!L.Browser.mobile}"]`

**Note**: Gutenburg blocks must be a shortcode block for this to be parsed properly!

<img width="444" alt="image" src="https://user-images.githubusercontent.com/1410985/96323704-b64f0180-0ff4-11eb-9938-5fca5421901c.png">

<img width="749" alt="Screen Shot 2020-10-16 at 9 16 26 PM" src="https://user-images.githubusercontent.com/1410985/96323764-04640500-0ff5-11eb-8c74-d3775289e11b.png">

Closes #112
Closes #108 