### PR TITLE
Allow Gallery inside Leaflet Popup Message to display in a Lightbox

### DIFF
--- a/class.leaflet-map.php
+++ b/class.leaflet-map.php
@@ -381,13 +381,14 @@ class Leaflet_Map
         // e.g. [leaflet-marker][some-shortcode][/leaflet-marker]
         $message = do_shortcode($message);
         $message = str_replace(array("\r\n", "\n", "\r"), '<br>', $message);
-        $message = addslashes($message);
-        $message = htmlspecialchars($message);
+        // $message = addslashes($message);
+        // $message = htmlspecialchars($message);
         $visible = empty($visible) 
             ? false 
             : filter_var($visible, FILTER_VALIDATE_BOOLEAN);
 
-        echo "{$shape}.bindPopup(window.WPLeafletMapPlugin.unescape('{$message}'))";
+        // echo "{$shape}.bindPopup(window.WPLeafletMapPlugin.unescape('{$message}'))";
+        echo "{$shape}.bindPopup(`{$message}`)";
         if ($visible) {
             echo ".openPopup()";
         }


### PR DESCRIPTION
### Steps to Reproduce
1. **Create a [Leaflet Popup custom post type,](https://pastebin.com/itVSny23) ,create a [Shortcode that calls the Custom Post Type](https://pastebin.com/CEyS7ZVT), add some content and a gallery to the CPT:**

![image](https://user-images.githubusercontent.com/26258032/218214149-476f5bd1-d8c6-439f-bf43-6a0bca32e881.png)
_Image 1: Leaflet Popups CPT_

![image](https://user-images.githubusercontent.com/26258032/218207934-c59295d9-d0cb-4f72-bc72-1fa82579a735.png)
_Image 2: Adding Content to Leaflet Popups CPT_

2. **Link Gallery images to Media Files**

This is an important step in order to enable the lightbox

![image](https://user-images.githubusercontent.com/26258032/218208065-7fc28f07-c0a1-4ff9-8a2c-a2bd10c79848.png)
_Image 3: Link Gallery images to Media Files to enable lightbox_

3. **Install [Lightbox with Photoswipe](https://wordpress.org/plugins/lightbox-photoswipe/) plugin**
We need it for the Lightbox to work.

5. Add the  Shortcode in any page with leaflet map like so (replace id with the custom post type id)
```
[leaflet-marker lat=37.79418967176286 lng= -122.40021432209008]
[leaflet-popup id=340]
[/leaflet-marker]
```

![image](https://user-images.githubusercontent.com/26258032/218212912-44356dae-11eb-4766-9371-963107af1b2d.png)
_Image 4: Leaflet Map with a Leaflet Popup that contains a CPT with a gallery_

(By the way, there is some overflow which wasn't in the previous plugin version (December 2022) and causes the header of the popup to be missing)

6. Try to click any gallery image and you will see that the lightbox is not working. In fact, header and footer are completely missing from html, I guess that is causing the issue :(

![image](https://user-images.githubusercontent.com/26258032/218211463-71ce839e-c15e-469f-983c-938d1c3af646.png)
_Image 5: Leaflet Map Lightbox Gallery not working_

### Expected result
The gallery and the lightbox should be working like so:
![image](https://user-images.githubusercontent.com/26258032/218210629-e4479a8a-4cdd-4c46-8224-a65056939edb.png)

### Proposed steps
The current PR comments the two problematic lines and the lightbox is now working when you click on an image from the gallery! 

### Conclusion
I suppose these lines are important for security, so I made it for testing purposes only, A better approach in my opinion, is to give users like me an option to override this function, at their own risk. Otherwise, I am not able to reproduce the design requirements and I am failing with the project unless I "hack" the plugin and get stuck with using an old and insecure version. Thank you for the understanding and hopefully a solution would be made soon