### PR TITLE
Plugin_Settings: mention on viewport sizes

### DIFF
--- a/class.plugin-settings.php
+++ b/class.plugin-settings.php
@@ -116,7 +116,7 @@ class Leaflet_Map_Plugin_Settings
                 'type' => 'text',
                 'helptext' => sprintf(
                     '%1$s %2$s <br /> <code>[leaflet-map height="250"]</code>', 
-                    __('Default height for maps. Values can include "px" but it is not necessary. Can also be "%". ', 'leaflet-map'),
+                    __('Default height for maps. Values can include "px" but it is not necessary. Can also be "%" or "vh".', 'leaflet-map'),
                     $foreachmap
                 )
             ),
@@ -126,7 +126,7 @@ class Leaflet_Map_Plugin_Settings
                 'type' => 'text',
                 'helptext' => sprintf(
                     '%1$s %2$s <br /> <code>[leaflet-map width="100%%"]</code>', 
-                    __('Default width for maps. Values can include "px" but it is not necessary.  Can also be "%".', 'leaflet-map'),
+                    __('Default width for maps. Values can include "px" but it is not necessary.  Can also be "%" or "vh".', 'leaflet-map'),
                     $foreachmap
                 )
             ),

--- a/languages/leaflet-map.pot
+++ b/languages/leaflet-map.pot
@@ -47,7 +47,7 @@ msgstr ""
 #: class.plugin-settings.php:92
 msgid ""
 "Default height for maps. Values can include \"px\" but it is not necessary. "
-"Can also be \"%\". "
+"Can also be \"%\" or \"vh\"."
 msgstr ""
 
 #: class.plugin-settings.php:97
@@ -57,7 +57,7 @@ msgstr ""
 #: class.plugin-settings.php:101
 msgid ""
 "Default width for maps. Values can include \"px\" but it is not necessary.  "
-"Can also be \"%\"."
+"Can also be \"%\" or \"vh\"."
 msgstr ""
 
 #: class.plugin-settings.php:106


### PR DESCRIPTION
Following up on #225 I thought it helpful to mention height and width settings relative to the viewport in the explanation.
For CSS-unsavy users like me it covers a standard use case (relative to what I see) as opposed to the percentage setting (relative to what?).

In case this pull request should be accepted I would also take care of the translations.