### PR TITLE
Version 3.4.2

### DIFF
--- a/leaflet-map.php
+++ b/leaflet-map.php
@@ -29,7 +29,7 @@ if (!defined('ABSPATH')) {
   exit();
 }
 
-define('LEAFLET_MAP__PLUGIN_VERSION', '3.4.1');
+define('LEAFLET_MAP__PLUGIN_VERSION', '3.4.2');
 define('LEAFLET_MAP__PLUGIN_FILE', __FILE__);
 define('LEAFLET_MAP__PLUGIN_DIR', plugin_dir_path(__FILE__));
 

--- a/leaflet-map.php
+++ b/leaflet-map.php
@@ -8,7 +8,7 @@
  * Author URI: https://bozdoz.com/
  * Text Domain: leaflet-map
  * Domain Path: /languages/
- * Version: 3.4.1
+ * Version: 3.4.2
  * License: GPL2
  * Leaflet Map is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wp-plugin-leaflet-map",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wp-plugin-leaflet-map",
-      "version": "3.4.1",
+      "version": "3.4.2",
       "license": "GPL-2.0",
       "devDependencies": {
         "jest": "^27.0.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wp-plugin-leaflet-map",
   "private": true,
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Leaflet Map WordPress Plugin",
   "scripts": {
     "start": "docker-compose up && exit 0",

--- a/readme.txt
+++ b/readme.txt
@@ -7,8 +7,8 @@ Donate link: https://www.paypal.me/bozdoz
 Tags: leaflet, map, openstreetmap, mapquest, interactive
 Requires at least: 4.6
 Tested up to: 6.8
-Version: 3.4.1
-Stable tag: 3.4.1
+Version: 3.4.2
+Stable tag: 3.4.2
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -153,8 +153,10 @@ For more FAQs, please visit the [FAQ section on GitHub here](https://github.com/
 
 == Changelog ==
 
+= 3.4.2 =
+* [Update] New default tile urls, removed subdomains
 
-= 3.4.0 =
+= 3.4.1 =
 * [Update] Compatible with PHP 8.2
 
 = 3.4.0 =


### PR DESCRIPTION
Hi Bozdoz,

I create a new PR, because some changes are not in version 3.4.1. WordPress created a new zip file for 3.4.1, but the users don't get an update notice, because it is not a NEW version.
See my comment here: https://github.com/bozdoz/wp-plugin-leaflet-map/pull/265#issuecomment-2773567119

Thank you.
