### PR TITLE
map height helper page, doubleClickZoom

### DIFF
--- a/shortcodes/class.map-shortcode.php
+++ b/shortcodes/class.map-shortcode.php
@@ -85,8 +85,11 @@ class Leaflet_Map_Shortcode extends Leaflet_Shortcode
             : (array_key_exists('scrollwheel', $atts)
                 ? $scrollwheel
                 : $settings->get('scroll_wheel_zoom'));
-        $atts['doubleclickzoom'] = array_key_exists('doubleclickzoom', $atts) ?
-            $doubleclickzoom : $settings->get('double_click_zoom');
+         $atts['doubleclickzoom'] = isset($doubleClickZoom)
+             ? $doubleClickZoom
+             : (array_key_exists('doubleclickzoom', $atts)
+                 ? $doubleclickzoom
+                 : $settings->get('double_click_zoom'));
 
         // @deprecated backwards-compatible fit_markers
         $atts['fit_markers'] = array_key_exists('fit_markers', $atts) ?

--- a/style.css
+++ b/style.css
@@ -112,3 +112,7 @@ p {
 .list-item p {
   font-size: 1.2em;
 }
+
+.examples .leaflet-container {
+  height: 250px !important;
+}


### PR DESCRIPTION
Hi Bozdoz,

I hope, it is correct now. I fixed [this](https://wordpress.org/support/topic/how-to-disable-double-clicking/) and [this](https://wordpress.org/support/topic/bug-broken-layout-shortcode-helper/).

Thank you very much.