### PR TITLE
WP 7.1, settings page

### DIFF
--- a/class.plugin-option.php
+++ b/class.plugin-option.php
@@ -108,6 +108,7 @@ class Leaflet_Map_Plugin_Option
     {
         switch ($this->type) {
         case 'text':
+        case 'email':
             ?>
         <input 
             class="full-width" 
@@ -142,7 +143,7 @@ class Leaflet_Map_Plugin_Option
         <textarea 
             id="<?php echo esc_attr( $name ); ?>"
             class="full-width" 
-            name="<?php echo esc_attr( $name ); ?>"><?php echo esc_attr( $value ); ?></textarea>
+            name="<?php echo esc_attr( $name ); ?>"><?php echo esc_textarea( $value ); ?></textarea>
 
             <?php
             break;

--- a/class.plugin-settings.php
+++ b/class.plugin-settings.php
@@ -191,7 +191,7 @@ class Leaflet_Map_Plugin_Settings
 				'max' => 20,
 				'step' => 1,
                 'helptext' => sprintf(
-                    '%1$s %2%s <br /> <code>%3$s</code>', 
+                    '%1$s %2$s <br /> <code>%3$s</code>',
                     __('Restrict the viewer from zooming out past the maximum zoom.  Can set per map in shortcode or adjust for all maps here', 'leaflet-map'),
                     $foreachmap,
                     '[leaflet-map max_zoom="10"]'
@@ -209,7 +209,8 @@ class Leaflet_Map_Plugin_Settings
             ),
             'mapquest_appkey' => array(
                 'display_name'=>__('MapQuest API Key (optional)', 'leaflet-map'),
-                'default' => __('Supply an API key if you choose MapQuest', 'leaflet-map'),
+                'default' => '',
+                'placeholder'  => __('Supply an API key if you choose MapQuest', 'leaflet-map'),
                 'type' => 'text',
                 'noreset' => true,
                 'helptext' => sprintf(
@@ -236,7 +237,8 @@ class Leaflet_Map_Plugin_Settings
             ),
             'map_tile_url_subdomains' => array(
                 'display_name'=>__('Map Tile URL Subdomains', 'leaflet-map'),
-                'default'=>'abc',
+                'default'=>'',
+                'placeholder'=>'abc',
                 'type' => 'text',
                 'helptext' => sprintf(
                     '%1$s %2$s <br/> <code>[leaflet-map subdomains="1234"]</code>',
@@ -349,7 +351,7 @@ class Leaflet_Map_Plugin_Settings
             'nominatim_contact_email' => array(
                 'display_name'=>__('Nominatim Contact Email (optional)', 'leaflet-map'),
                 'default' => '',
-                'type' => 'text',
+                'type' => 'email',
                 'placeholder' => sprintf(
                     __('defaults to admin email (%s)', 'leaflet-map'),
                     get_bloginfo('admin_email')
@@ -361,7 +363,8 @@ class Leaflet_Map_Plugin_Settings
             ),
             'google_appkey' => array(
                 'display_name'=>__('Google API Key (optional)', 'leaflet-map'),
-                'default' => __('Supply a Google API Key', 'leaflet-map'),
+                'default' => '',
+                'placeholder'  => __('Supply a Google API Key', 'leaflet-map'),
                 'type' => 'text',
                 'noreset' => true,
                 'helptext' => sprintf(

--- a/leaflet-map.php
+++ b/leaflet-map.php
@@ -8,7 +8,7 @@
  * Author URI: https://bozdoz.com/
  * Text Domain: leaflet-map
  * Domain Path: /languages/
- * Version: 3.4.6
+ * Version: 3.4.7
  * License: GPL2
  * Leaflet Map is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,7 +29,7 @@ if (!defined('ABSPATH')) {
   exit();
 }
 
-define('LEAFLET_MAP__PLUGIN_VERSION', '3.4.6');
+define('LEAFLET_MAP__PLUGIN_VERSION', '3.4.7');
 define('LEAFLET_MAP__PLUGIN_FILE', __FILE__);
 define('LEAFLET_MAP__PLUGIN_DIR', plugin_dir_path(__FILE__));
 

--- a/readme.txt
+++ b/readme.txt
@@ -6,9 +6,9 @@ Contributors: bozdoz, hupe13, jannefleischer, remigr, gerital, sal0max, thibault
 Donate link: https://www.paypal.me/bozdoz
 Tags: leaflet, map, openstreetmap, mapquest, interactive
 Requires at least: 4.6
-Tested up to: 6.9
-Version: 3.4.6
-Stable tag: 3.4.6
+Tested up to: 7.1
+Version: 3.4.7
+Stable tag: 3.4.7
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -156,6 +156,10 @@ For more FAQs, please visit the [FAQ section on GitHub here](https://github.com/
 8. MapQuest requires an app key, get it from their website; alternatively, you can use OpenStreetMap as a free tile service (remember to add an attribution where necessary).
 
 == Changelog ==
+
+= 3.4.7 =
+* Tested with WordPress 7.1
+* some corrections to option types
 
 = 3.4.6 =
 * [Bugfix] Fix to escaping geojson url's

--- a/shortcodes/class.map-shortcode.php
+++ b/shortcodes/class.map-shortcode.php
@@ -174,7 +174,7 @@ class Leaflet_Map_Shortcode extends Leaflet_Shortcode
         // custom field for moving to javascript
         // filter out any unwanted HTML tags (including img)
         if ($atts['attribution'] !== 0) {
-            $map_options['attribution'] = wp_kses_post($atts['attribution']);
+            $map_options['attribution'] = wp_kses_post( html_entity_decode( $atts['attribution'] ) );
         }
 
         // wrap as JSON

--- a/style.css
+++ b/style.css
@@ -44,6 +44,7 @@ code {
 
 .input-group input[type='number'],
 .input-group input[type='text'],
+.input-group input[type='email'],
 .input-group textarea,
 .input-group select {
   width: 100%;


### PR DESCRIPTION
I reworked my [last](https://github.com/bozdoz/wp-plugin-leaflet-map/pull/297) (deleted) pull request and here is a now one:

* Tested up to WordPress 7.1
* some changes in settings page: 
* a typo, 
* handling of html  chars like `&copy;` in attribution, 
* testing format of email 
* and more.

Please check and approve.

Thank you very much.